### PR TITLE
Correct a typo. Remove '2' from 'sampleForIAMServiceRoles'

### DIFF
--- a/iam-service-roles/service-role.yaml
+++ b/iam-service-roles/service-role.yaml
@@ -30,7 +30,7 @@ Resources:
                     - ''
                     - - 'arn:aws:dynamodb:*:'
                       - !Ref AWS::AccountId
-                      - ':table/sampleForIAMServiceRoles2'
+                      - ':table/sampleForIAMServiceRoles'
 
 Outputs:
   ServiceRoleARN:


### PR DESCRIPTION
The dynamodb table name should be 'sampleForIAMServiceRoles', not 'sampleForIAMServiceRoles2'. 